### PR TITLE
Improve Errors::Unwrappable message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2019-02-05
+### Added
+- Change error message for `.wrap` from `Can't wrap OtherClass` to `MyClass can't wrap OtherClass`
+
 ## [0.5.1] - 2018-01-14
 ### Added
 - This CHANGELOG
-- Renamed ValueObject::Simple -> ValueObject::Single  
+- Renamed ValueObject::Simple -> ValueObject::Single
 
 ### Changed
 - RUS Guideline: Entity - improve orthography and punctuation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - 2019-02-05
+## [0.5.4] - 2019-02-05
 ### Added
 - Change error message for `.wrap` from `Can't wrap OtherClass` to `MyClass can't wrap OtherClass`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    luna_park (0.5.3)
+    luna_park (0.5.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/luna_park/entities/nested.rb
+++ b/lib/luna_park/entities/nested.rb
@@ -55,7 +55,7 @@ module LunaPark
           case input
           when self then input
           when Hash then new(input)
-          else raise Errors::Unwrapable, "Can`t wrap #{input.class}"
+          else raise Errors::Unwrapable, "#{self} can`t wrap #{input.class}"
           end
         end
 

--- a/lib/luna_park/values/compound.rb
+++ b/lib/luna_park/values/compound.rb
@@ -20,7 +20,7 @@ module LunaPark
           case input
           when self then input
           when Hash then new(input)
-          else raise Errors::Unwrapable, "Can`t wrap #{input.class}"
+          else raise Errors::Unwrapable, "#{self} can`t wrap #{input.class}"
           end
         end
       end

--- a/lib/luna_park/values/single.rb
+++ b/lib/luna_park/values/single.rb
@@ -27,7 +27,7 @@ module LunaPark
         def wrap(input)
           return input if input.is_a?(self)
 
-          raise Errors::Unwrapable, "Can`t wrap #{input.class}"
+          raise Errors::Unwrapable, "#{self} can`t wrap #{input.class}"
         end
       end
     end

--- a/lib/luna_park/version.rb
+++ b/lib/luna_park/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LunaPark
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -22,7 +22,7 @@ module LunaPark
       end
 
       it 'raises error with expected message' do
-        expect { wrap }.to raise_error "Can`t wrap #{input.class}"
+        expect { wrap }.to raise_error "#{object.class} can`t wrap #{input.class}"
       end
     end
   end


### PR DESCRIPTION
```
MyEntity.wrap(MyOtherEntity.new)
# => raise "MyEntity can't wrap MyOtherEntity"
```

Вместо

```
MyEntity.wrap(MyOtherEntity.new)
# => raise "Can't wrap MyOtherEntity"
```

Облегчает дебаг.