### PR TITLE
Draft Add Utils::SuperclassEval.superclass_eval

### DIFF
--- a/lib/luna_park.rb
+++ b/lib/luna_park.rb
@@ -15,6 +15,7 @@ module LunaPark
 end
 
 require_relative 'luna_park/errors'
+require_relative 'luna_park/utils/superclass_eval'
 require_relative 'luna_park/extensions/attributable'
 require_relative 'luna_park/extensions/wrappable'
 require_relative 'luna_park/extensions/callable'

--- a/lib/luna_park/entities/nested.rb
+++ b/lib/luna_park/entities/nested.rb
@@ -12,13 +12,12 @@ module LunaPark
         namespace_class.define_singleton_method(:name) { "Namespace:#{name}" }
         namespace_class.class_eval(&block)
 
-        anonym_mixin = Module.new do
+        Utils::SuperclassEval.superclass_eval(self) do
           attr_reader(name)
           define_method(:"#{name}=") do |input|
             instance_variable_set(:"@#{name}", namespace_class.wrap(input))
           end
         end
-        include(anonym_mixin)
       end
     end
   end

--- a/lib/luna_park/extensions/typed_attr_accessor.rb
+++ b/lib/luna_park/extensions/typed_attr_accessor.rb
@@ -9,19 +9,22 @@ module LunaPark
       end
 
       def typed_attr_writer(*names, callable, is_array: false) # rubocop:disable Metrics/MethodLength
-        return attr_writer(*names) if callable.nil?
+        mixin = Module.new do
+          return attr_writer(*names) if callable.nil?
 
-        names.each do |name|
-          setter = :"#{name}="
-          ivar   = :"@#{name}"
-          Utils::SuperclassEval.superclass_eval(self) do
-            if is_array
-              define_method(setter) { |input| instance_variable_set(ivar, input&.map { |elem| callable.call(elem) }) }
-            else
-              define_method(setter) { |input| instance_variable_set(ivar, callable.call(input)) }
+          names.each do |name|
+            setter = :"#{name}="
+            ivar   = :"@#{name}"
+            Utils::SuperclassEval.superclass_eval(self) do
+              if is_array
+                define_method(setter) { |input| instance_variable_set(ivar, input&.map { |elem| callable.call(elem) }) }
+              else
+                define_method(setter) { |input| instance_variable_set(ivar, callable.call(input)) }
+              end
             end
           end
         end
+        include(mixin)
       end
     end
   end

--- a/lib/luna_park/extensions/typed_attr_accessor.rb
+++ b/lib/luna_park/extensions/typed_attr_accessor.rb
@@ -4,20 +4,22 @@ module LunaPark
   module Extensions
     module TypedAttrAccessor
       def typed_attr_accessor(*names, callable, is_array: false)
-        attr_reader(*names)
+        Utils::SuperclassEval.superclass_eval(self) { attr_reader(*names) }
         typed_attr_writer(*names, callable, is_array: is_array)
       end
 
-      def typed_attr_writer(*names, callable, is_array: false)
+      def typed_attr_writer(*names, callable, is_array: false) # rubocop:disable Metrics/MethodLength
         return attr_writer(*names) if callable.nil?
 
         names.each do |name|
           setter = :"#{name}="
           ivar   = :"@#{name}"
-          if is_array
-            define_method(setter) { |input| instance_variable_set(ivar, input&.map { |elem| callable.call(elem) }) }
-          else
-            define_method(setter) { |input| instance_variable_set(ivar, callable.call(input)) }
+          Utils::SuperclassEval.superclass_eval(self) do
+            if is_array
+              define_method(setter) { |input| instance_variable_set(ivar, input&.map { |elem| callable.call(elem) }) }
+            else
+              define_method(setter) { |input| instance_variable_set(ivar, callable.call(input)) }
+            end
           end
         end
       end

--- a/lib/luna_park/utils/superclass_eval.rb
+++ b/lib/luna_park/utils/superclass_eval.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module LunaPark
+  module Utils
+    ##
+    # hack for defining meta-methods with available super methods
+    #
+    # When you defines Foo.attr_accessor or same dsl that dynamicaly defines methods,
+    #   you defines it in your class Foo, so thea have not superclass methods.
+    #   So if you want to redefine those methods using `super` - you can't
+    #
+    # This module allows you to define any methods as methods in anonym mixin
+    #   So if you want to redefine those methods using `super` - you can,
+    #     if  those methods will be defined in block `superclass_eval`
+    #
+    # @example
+    #   class Foo
+    #     attr_accessor :foo
+    #     def foo=(input)
+    #       super(input.downcase)
+    #     end
+    #   end
+    #   o = Foo.new
+    #   o.foo = 'FOO' # => raise Unknown supermethod `foo`
+    #
+    #   class Bar
+    #     extend LunaPark::Utils::SuperclassEval
+    #
+    #     superclass_eval do
+    #       attr_accessor :bar
+    #     end
+    #
+    #     def foo=(input)
+    #       super(input.downcase)
+    #     end
+    #   end
+    #
+    #   o = Foo.new
+    #   o.bar = 'BAR'
+    #   o.bar # => 'bar'
+    module SuperclassEval
+      IVAR = :@__anonym_mixin__
+
+      def superclass_eval(&block)
+        SuperclassEval.superclass_eval(self, &block)
+      end
+
+      class << self
+        def superclass_eval(base, &block)
+          anonym_mixin_at(base).class_eval(&block)
+        end
+
+        private
+
+        def anonym_mixin_at(base)
+          base.instance_variable_get(IVAR) || base.instance_variable_set(IVAR, new_anonym_mixin_at(base))
+        end
+
+        def new_anonym_mixin_at(base)
+          Module.new.tap { |anonim_mixin| base.include(anonim_mixin) }
+        end
+      end
+    end
+  end
+end

--- a/spec/luna_park/extensions/dsl/attributes_spec.rb
+++ b/spec/luna_park/extensions/dsl/attributes_spec.rb
@@ -110,5 +110,26 @@ module LunaPark
         end
       end
     end
+
+    context 'when redefined with `super`' do
+      before do
+        klass.class_eval do
+          def eyes_count=(i)
+            super(i.to_s)
+          end
+
+          def alive=(i)
+            super(!!i)
+          end
+        end
+      end
+
+      it 'from #attr, workes with super' do
+        expect { e.eyes_count = '8' }.not_to raise_error
+      end
+      it 'from #attr?, workes with super' do
+        expect { e.alive = 'yes' }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Если объявлять метод через, например, attr_accessor, то метод создаётся именно в текущем классе.
Если попытаться его переопределить в этом же классе, вызвав в переопределении super - мы получим ошибку, сообщающую о том что такого суперметода не, то есть лукап метода пуст и брать super неоткуда.

```
class Foo
  attr_accessor :foo

  def foo=(input)
    super(input.downcase)
  end
end

o = Foo.new
o.foo = 'FOO' # => raise unknown supermethod `foo`
```

Что бы super появился, нужно чтоб этот метод был объявлен в суперклассе или в подмешанном через include миксине

Что бы не писать каждый раз одинаковое не красивое решение, сделан модуль `LunaPark::Utils::SuperclassEval` с методамм `.superclass_eval(base, &block)`, `#superclass_eval(&block)`

```
class Bar
  extend LunaPark::Utils::SuperclassEval

  superclass_eval do
    attr_accessor :bar
  end

  def foo=(input)
    super(input.downcase)
  end
end

o = Foo.new
o.bar = 'BAR'
o.bar # => 'bar
```

Модуль можно использовать и без extend:

```
class Bar
  LunaPark::Utils::SuperclassEval.superclass_eval(self) do
    attr_accessor :bar
  end

  def foo=(input)
    super(input.downcase)
  end
end
```

# Минус подобного решения:
Кроме магии, пусть и полезной,
в блоке `superclass_eval` доступны только те методы что доступны в обычном пустом Module, и те переменные что попали в блок из скоупа в котором тот вызывается.

```
class Bar
  extend LunaPark::Utils::SuperclassEval

  def self.my_attr_accessor(*args)
    # ...
  end

  superclass_eval do
    my_attr_accessor :bar
  end

  def foo=(input)
    super(input.downcase)
  end
end

# => NoMethodError:
# =>   undefined method `my_attr_accessor' for #<Module:0x00007fcfe6cfb968>
```