### PR TITLE
CI: Drop sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
  - The Travis setting sudo: false has been removed - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration