### PR TITLE
Add #errors_array, rename #errors to #errors_tree with save as alias

### DIFF
--- a/lib/luna_park/extensions/validatable.rb
+++ b/lib/luna_park/extensions/validatable.rb
@@ -37,6 +37,14 @@ module LunaPark
       end
 
       module InstanceMethods
+        def validation_errors_array
+          validation ? validation.errors_array : {}
+        end
+
+        def validation_errors_tree
+          validation ? validation.errors_tree : []
+        end
+
         def validation_errors
           validation ? validation.errors : {}
         end

--- a/lib/luna_park/validators/dry.rb
+++ b/lib/luna_park/validators/dry.rb
@@ -17,9 +17,15 @@ module LunaPark
         (success? && result.to_h) || {}
       end
 
-      def errors
+      def errors_array
+        result.errors.map { |error| { path: error.path, text: error.text, input: error.input } }
+      end
+
+      def errors_tree
         result.errors.to_h || {}
       end
+
+      alias errors errors_tree
 
       private
 

--- a/spec/luna_park/extensions/validatable_spec.rb
+++ b/spec/luna_park/extensions/validatable_spec.rb
@@ -10,12 +10,14 @@ module ExtensionsValidatableSpec
       @params = params
     end
 
-    def errors
-      @errors ||= {}.tap do |errors|
+    def errors_tree
+      @errors_tree ||= {}.tap do |errors|
         errors[:foo] ||= 'is missing' unless @params.key?(:foo) || @params.key?('foo')
         errors[:bar] ||= 'is missing' unless @params.key?(:bar) || @params.key?('bar')
       end
     end
+
+    alias errors errors_tree
 
     def success?
       errors.empty?

--- a/spec/luna_park/validators/dry_spec.rb
+++ b/spec/luna_park/validators/dry_spec.rb
@@ -80,6 +80,43 @@ RSpec.describe LunaPark::Validators::Dry do
     end
   end
 
+  describe '#errors_tree' do
+    subject { validator.errors_tree }
+
+    context 'when sent valid params' do
+      let(:params) { valid_params }
+
+      it { is_expected.to be_a Hash }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when sent invalid params' do
+      let(:params) { invalid_params }
+
+      it { is_expected.to be_a Hash }
+      it { is_expected.to_not be_empty }
+    end
+  end
+
+  describe '#errors_array' do
+    subject { validator.errors_array }
+
+    context 'when sent valid params' do
+      let(:params) { valid_params }
+
+      it { is_expected.to be_a Array }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when sent invalid params' do
+      let(:params) { invalid_params }
+
+      it { is_expected.to be_a Array }
+      it { is_expected.to_not be_empty }
+      it { is_expected.to eq [path: [:type], text: 'must be equal to human', input: 'robot'] }
+    end
+  end
+
   describe '.validate' do
     subject { validator_class.validate(valid_params) }
 


### PR DESCRIPTION
Validator (и соответственно Validatable) теперь могут возвращать не только дерево, но и массив ошибок, где каждым элементом будет
```
{ path: %i[путь до значения в исходном хэшмапе], text: "текст ошибки", input: "входящее значение" }