### PR TITLE
LunaPark::Http::Client, Request refactoring

### DIFF
--- a/lib/luna_park/errors/http.rb
+++ b/lib/luna_park/errors/http.rb
@@ -51,7 +51,7 @@ module LunaPark
       #   #  status: 'OK',
       #   #  request: {
       #   #    body: '{"message":"ping"}',
-      #   #    http_method: :post,
+      #   #    method: :post,
       #   #    headers: {'Content-Type': 'application/json'},
       #   #    open_timeout: 10,
       #   #    read_timeout: 10,
@@ -71,7 +71,7 @@ module LunaPark
           title: request.title,
           status: response.status,
           request: {
-            http_method: request.http_method,
+            method: request.method,
             url: request.url,
             body: request.body,
             headers: request.headers,

--- a/lib/luna_park/http/client.rb
+++ b/lib/luna_park/http/client.rb
@@ -92,7 +92,7 @@ module LunaPark
     #   checkout.call
     #   checkout.success?     # => false
     #   checkout.fail_message # => "Not enough funds in your account"
-    class Client # rubocop:disable Metrics/ClassLength
+    class Client
       DEFAULT_OPEN_TIMEOUT = 10
       DEFAULT_READ_TIMEOUT = 10
       DEFAULT_DRIVER       = LunaPark::Http::Send
@@ -118,8 +118,8 @@ module LunaPark
       #
       # @return [LunaPark::Http::Request]
       # rubocop:disable Metrics/ParameterLists
-      def form_request(title:, url:, method: nil, body: nil, data: nil, headers: nil, **opts)
-        form_body = body || data # we have no a good generator for `x-www-form-urlencoded`, but Driver has
+      def form_request(title:, url:, method: nil, body: nil, headers: nil, data: nil, **opts)
+        form_body = body || data # * we have no a good generator for `x-www-form-urlencoded` type, but Driver has
 
         build_request(
           title: title,
@@ -187,35 +187,35 @@ module LunaPark
       #
       # @return [LunaPark::Http::Response]
       def get(request)
-        request.http_method = :get
+        request.method = :get
         request.call
       end
 
       # Send POST request. Always return response even if the response is not successful.
       # @see #get
       def post(request)
-        request.http_method = :post
+        request.method = :post
         request.call
       end
 
       # Send PUT request. Always return response even if the response is not successful.
       # @see #get
       def put(request)
-        request.http_method = :put
+        request.method = :put
         request.call
       end
 
       # Send PATCH request. Always return response even if the response is not successful.
       # @see #get
       def patch(request)
-        request.http_method = :patch
+        request.method = :patch
         request.call
       end
 
       # Send DELETE request. Always return response even if the response is not successful.
       # @see #get
       def delete(request)
-        request.http_method = :delete
+        request.method = :delete
         request.call
       end
 
@@ -234,50 +234,49 @@ module LunaPark
       # @raise [LunaPark::Errors::Http] on bad response, timeout or server is unavailable
       # @return [LunaPark::Http::Response]
       def get!(request)
-        request.http_method = :get
+        request.method = :get
         request.call!
       end
 
       # Send POST request. Raise {LunaPark::Errors::Http} on bad response.
       # @see #get!
       def post!(request)
-        request.http_method = :post
+        request.method = :post
         request.call!
       end
 
       # Send PUT request. Raise {LunaPark::Errors::Http} on bad response.
       # @see #get!
       def put!(request)
-        request.http_method = :put
+        request.method = :put
         request.call!
       end
 
       # Send PATCh request. Raise {LunaPark::Errors::Http} on bad response.
       # @see #get!
       def patch!(request)
-        request.http_method = :patch
+        request.method = :patch
         request.call!
       end
 
       # Send DELETE request. Raise {LunaPark::Errors::Http} on bad response.
       # @see #get!
       def delete!(request)
-        request.http_method = :delete
+        request.method = :delete
         request.call!
       end
 
-      def build_request(title:, url:, method: nil, body: nil, headers: nil, content_type: nil, open_timeout: nil, read_timeout: nil, driver: nil) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
-        # url_ = Utils::URI.wrap(url)
-        # url_&.query = query
+      private
 
+      def build_request(title:, url:, method: nil, body: nil, headers: nil, content_type: nil, open_timeout: nil, read_timeout: nil, driver: nil) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         headers ||= {}
         headers['Content-Type'] = content_type || 'text/plain'
 
         # rubocop:disable Layout/HashAlignment
         Request.new(
           title:        title,
-          url:          url.to_s,
-          method:  method || DEFAULT_METHOD,
+          url:          url.to_s, # TODO: Use {LunaPark::Tools::URI} with @query
+          method:       method || DEFAULT_METHOD,
           body:         body,
           headers:      headers,
           open_timeout: open_timeout || self.class.open_timeout,
@@ -288,7 +287,7 @@ module LunaPark
       end
 
       class << self
-        # Set diver for this class
+        # Set default diver for this Client
         #
         # @example set driver
         #   class Users < Client
@@ -296,15 +295,30 @@ module LunaPark
         #   end
         #
         #   Foobar.driver # => URI::Send
-        #   Foobar.new.driver     # => URI::Send
         def driver(driver = :undefined)
           driver == :undefined ? @driver || DEFAULT_DRIVER : @driver = driver
         end
 
+        # Set default open_timeout for this Client
+        #
+        # @example set open_timeout
+        #   class Users < Client
+        #     open_timeout URI::Send
+        #   end
+        #
+        #   Foobar.open_timeout # => URI::Send
         def open_timeout(timeout = :undefined)
           timeout == :undefined ? @open_timeout || DEFAULT_OPEN_TIMEOUT : @open_timeout = timeout
         end
 
+        # Set default read_timeout for this Client
+        #
+        # @example set read_timeout
+        #   class Users < Client
+        #     read_timeout URI::Send
+        #   end
+        #
+        #   Foobar.read_timeout     # => URI::Send
         def read_timeout(timeout = :undefined)
           timeout == :undefined ? @read_timeout || DEFAULT_READ_TIMEOUT : @read_timeout = timeout
         end

--- a/lib/luna_park/http/client.rb
+++ b/lib/luna_park/http/client.rb
@@ -295,8 +295,8 @@ module LunaPark
         #   end
         #
         #   Foobar.driver # => URI::Send
-        def driver(driver = :undefined)
-          driver == :undefined ? @driver || DEFAULT_DRIVER : @driver = driver
+        def driver(driver = nil)
+          driver.nil? ? @driver || DEFAULT_DRIVER : @driver = driver
         end
 
         # Set default open_timeout for this Client
@@ -307,8 +307,8 @@ module LunaPark
         #   end
         #
         #   Foobar.open_timeout # => URI::Send
-        def open_timeout(timeout = :undefined)
-          timeout == :undefined ? @open_timeout || DEFAULT_OPEN_TIMEOUT : @open_timeout = timeout
+        def open_timeout(timeout = nil)
+          timeout.nil? ? @open_timeout || DEFAULT_OPEN_TIMEOUT : @open_timeout = timeout
         end
 
         # Set default read_timeout for this Client
@@ -319,8 +319,8 @@ module LunaPark
         #   end
         #
         #   Foobar.read_timeout     # => URI::Send
-        def read_timeout(timeout = :undefined)
-          timeout == :undefined ? @read_timeout || DEFAULT_READ_TIMEOUT : @read_timeout = timeout
+        def read_timeout(timeout = nil)
+          timeout.nil? ? @read_timeout || DEFAULT_READ_TIMEOUT : @read_timeout = timeout
         end
       end
     end

--- a/lib/luna_park/http/client.rb
+++ b/lib/luna_park/http/client.rb
@@ -124,7 +124,7 @@ module LunaPark
         build_request(
           title: title,
           url: url,
-          http_method: method,
+          method: method,
           body: form_body,
           headers: headers,
           content_type: 'application/x-www-form-urlencoded',
@@ -163,7 +163,7 @@ module LunaPark
         build_request(
           title: title,
           url: url,
-          http_method: method,
+          method: method,
           body: json_body,
           headers: headers,
           content_type: 'application/json',

--- a/lib/luna_park/http/client.rb
+++ b/lib/luna_park/http/client.rb
@@ -172,10 +172,6 @@ module LunaPark
       end
       # rubocop:enable Metrics/ParameterLists
 
-      def request(title:, url:, method: nil, body: nil, headers: nil, **opts) # rubocop:disable Metrics/ParameterLists
-        build_request(title: title, url: url, http_method: method, body: body, headers: headers, **opts)
-      end
-
       # Send GET request. Always return response even if the response is not successful.
       #
       # @example success response
@@ -281,7 +277,7 @@ module LunaPark
         Request.new(
           title:        title,
           url:          url.to_s,
-          http_method:  method || DEFAULT_METHOD,
+          method:  method || DEFAULT_METHOD,
           body:         body,
           headers:      headers,
           open_timeout: open_timeout || self.class.open_timeout,

--- a/lib/luna_park/http/request.rb
+++ b/lib/luna_park/http/request.rb
@@ -31,6 +31,8 @@ module LunaPark
         name.nil? ? @method : super(name)
       end
 
+      attr_writer :method
+
       # Http url to send request
       #
       # @example Get users request

--- a/lib/luna_park/http/request.rb
+++ b/lib/luna_park/http/request.rb
@@ -18,7 +18,7 @@ module LunaPark
       #   request.title # => 'Get users list'
       attr_accessor :title
 
-      # Http method of current request, defines a set of
+      # Http http_method of current request, defines a set of
       # request methods to indicate the desired action to
       # be performed for a given resource
       #
@@ -82,17 +82,17 @@ module LunaPark
       # Create new request
       #
       # @param title business description (see #title)
-      # @param method Http method of current request (see #method)
+      # @param http_method Http http_method of current request (see #http_method)
       # @param url (see #url)
       # @param body (see #body)
       # @param headers (see #headers)
       # @param read_timeout (see #read_timeout)
       # @param open_timeout (see #open_timeout)
       # @param driver is HTTP driver which use to send this request
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(title:, method: nil, url: nil, body: nil, headers: nil, open_timeout: nil, read_timeout: nil, driver:)
+      # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+      def initialize(title:, http_method: nil, url: nil, body: nil, headers: nil, open_timeout: nil, read_timeout: nil, driver:)
         @title        = title
-        @method       = method
+        @http_method  = http_method
         @url          = url
         @body         = body
         @headers      = headers
@@ -103,14 +103,14 @@ module LunaPark
       end
       # rubocop:enable Metrics/ParameterLists, Layout/LineLength
 
-      # Send current request (we cannot call this method `send` because it
+      # Send current request (we cannot call this http_method `send` because it
       # reserved word in ruby). It always return Response object, even if
       # the server returned an error such as 404 or 502.
       #
       # @example correct answer
       #  request = Http::Request.new(
       #     title: 'Get users list',
-      #     method: :get,
+      #     http_method: :get,
       #     url: 'http:://yandex.ru'
       #   )
       #   request.call # => <LunaPark::Http::Response @code=200 @body="Hello World!" @headers={}>
@@ -120,7 +120,7 @@ module LunaPark
       #
       # After sending the request, the object is frozen. You should dup object to resend request.
       #
-      # @note This method implements a facade pattern. And you better use it
+      # @note This http_method implements a facade pattern. And you better use it
       #   than call the Http::Send class directly.
       #
       # @return LunaPark::Http::Response
@@ -130,14 +130,14 @@ module LunaPark
       end
 
       # Send the current request. It returns a Response object only on a successful response.
-      # If the response failed, the call! method should raise an Erros::Http exception.
+      # If the response failed, the call! http_method should raise an Erros::Http exception.
       #
       # After call! request you cannot change request attributes.
       #
       # @example correct answer
       #  request = Http::Request.new(
       #     title: 'Get users list',
-      #     method: :get,
+      #     http_method: :get,
       #     url: 'https://example.com/users'
       #   )
       #   request.call # => <LunaPark::Http::Response @code=200 @body="Hello World!" @headers={}>
@@ -147,7 +147,7 @@ module LunaPark
       #
       # After sending the request, the object is frozen. You should dup object to resend request.
       #
-      # @note This method implements a facade pattern. And you better use it
+      # @note This http_method implements a facade pattern. And you better use it
       #   than call the Http::Send class directly.
       #
       # @return LunaPark::Http::Response
@@ -162,14 +162,14 @@ module LunaPark
         @sent_at = nil
       end
 
-      # This method shows if this request has been already sent.
+      # This http_method shows if this request has been already sent.
       #
       # @return Boolean
       def sent?
         !@sent_at.nil?
       end
 
-      # This method return which driver are use, to send current request.
+      # This http_method return which driver are use, to send current request.
       def driver
         @driver ||= self.class.default_driver
       end
@@ -177,12 +177,12 @@ module LunaPark
       # @example inspect get users index request
       #   request = LunaPark::Http::Request.new(
       #     title: 'Get users',
-      #     method: :get,
+      #     http_method: :get,
       #     url: 'https://example.com/users'
       #   )
       #
       #   request.inspect # => "<LunaPark::Http::Request @title=\"Get users\"
-      #                   #  @url=\"http://localhost:8080/get_200\" @method=\"get\"
+      #                   #  @url=\"http://localhost:8080/get_200\" @http_method=\"get\"
       #                   #  @headers=\"{}\" @body=\"\" @sent_at=\"\">"
       def inspect
         "<#{self.class.name} "           \
@@ -196,7 +196,7 @@ module LunaPark
 
       # @example
       #   request.to_h # => {:title=>"Get users",
-      #                      :method=>:get,
+      #                      :http_method=>:get,
       #                      :url=>"http://localhost:8080/get_200",
       #                      :body=>nil,
       #                      :headers=>{},

--- a/lib/luna_park/http/request.rb
+++ b/lib/luna_park/http/request.rb
@@ -5,12 +5,6 @@ require 'luna_park/http/send'
 module LunaPark
   module Http
     class Request
-      DEFAULT_OPEN_TIMEOUT = 10
-      DEFAULT_READ_TIMEOUT = 10
-      DEFAULT_DRIVER       = LunaPark::Http::Send
-
-      private_constant :DEFAULT_DRIVER
-
       # Business description for this request, help you
       # make the domain model more expressive
       #
@@ -95,15 +89,15 @@ module LunaPark
       # @param read_timeout (see #read_timeout)
       # @param open_timeout (see #open_timeout)
       # @param driver is HTTP driver which use to send this request
-      # rubocop:disable Metrics/ParameterLists, Layout/LineLength
-      def initialize(title:, http_method:, url:, body: nil, headers: nil, open_timeout: nil, read_timeout: nil, driver: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(title:, method: nil, url: nil, body: nil, headers: nil, open_timeout: nil, read_timeout: nil, driver:)
         @title        = title
-        @http_method  = http_method
-        @url          = url # TODO: Utils::URI
+        @method       = method
+        @url          = url
         @body         = body
-        @headers      = headers      || {}
-        @read_timeout = read_timeout || DEFAULT_READ_TIMEOUT
-        @open_timeout = open_timeout || DEFAULT_OPEN_TIMEOUT
+        @headers      = headers
+        @read_timeout = read_timeout
+        @open_timeout = open_timeout
         @driver       = driver
         @sent_at      = nil
       end
@@ -219,26 +213,6 @@ module LunaPark
           open_timeout: open_timeout,
           sent_at: sent_at
         }
-      end
-
-      class << self
-        # @return Default driver
-        def default_driver
-          @default_driver ||= DEFAULT_DRIVER
-        end
-
-        # Set diver for this class
-        #
-        # @example set driver
-        #   class Users < Client
-        #     driver URI::Send
-        #   end
-        #
-        #   Foobar.default_driver # => URI::Send
-        #   Foobar.new.driver     # => URI::Send
-        def driver(driver)
-          @default_driver = driver
-        end
       end
     end
   end

--- a/lib/luna_park/http/send.rb
+++ b/lib/luna_park/http/send.rb
@@ -72,8 +72,8 @@ module LunaPark
 
       def build_rest_request(request)
         RestClient::Request.new(
-          url: request.url,
-          method: request.http_method,
+          url: request.url.to_s,
+          method: request.method,
           payload: request.body,
           headers: request.headers,
           open_timeout: request.open_timeout,

--- a/spec/luna_park/errors/http_spec.rb
+++ b/spec/luna_park/errors/http_spec.rb
@@ -49,7 +49,7 @@ module LunaPark
       let(:request) do
         Http::Request.new(
           title: 'Ping-pong',
-          http_method: :post,
+          method: :post,
           url: 'http://example.com/api/ping',
           body: JSON.generate(message: 'ping'),
           headers: { 'Content-Type' => 'application/json' },

--- a/spec/luna_park/errors/http_spec.rb
+++ b/spec/luna_park/errors/http_spec.rb
@@ -3,6 +3,7 @@
 require 'luna_park/http/request'
 require 'luna_park/http/response'
 require 'luna_park/errors/http'
+require 'luna_park/http/send'
 
 I18n.load_path << Dir['spec/locales/*.yml']
 
@@ -51,7 +52,8 @@ module LunaPark
           http_method: :post,
           url: 'http://example.com/api/ping',
           body: JSON.generate(message: 'ping'),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' },
+          driver: LunaPark::Http::Send
         )
       end
 
@@ -59,8 +61,8 @@ module LunaPark
         Http::Response.new(
           body: '{"message":"pong"}',
           code: 200,
-          headers: { 'Content-Type': 'application/json' },
-          cookies: { 'Secret': 'dkmvc9saudj3cndsaosp' },
+          headers: { 'Content-Type' => 'application/json' },
+          cookies: { 'Secret' => 'dkmvc9saudj3cndsaosp' },
           request: request
         )
       end
@@ -75,18 +77,18 @@ module LunaPark
           status: 'OK',
           request: {
             body: '{"message":"ping"}',
-            http_method: :post,
-            headers: { 'Content-Type': 'application/json' },
-            open_timeout: 10,
-            read_timeout: 10,
+            method: :post,
+            headers: { 'Content-Type' => 'application/json' },
+            open_timeout: nil,
+            read_timeout: nil,
             sent_at: nil,
             url: 'http://example.com/api/ping'
           },
           response: {
             body: '{"message":"pong"}',
             code: 200,
-            headers: { 'Content-Type': 'application/json' },
-            cookies: { 'Secret': 'dkmvc9saudj3cndsaosp' }
+            headers: { 'Content-Type' => 'application/json' },
+            cookies: { 'Secret' => 'dkmvc9saudj3cndsaosp' }
           },
           error_details: { something: 'important' }
         )

--- a/spec/luna_park/http/client_spec.rb
+++ b/spec/luna_park/http/client_spec.rb
@@ -19,7 +19,7 @@ module LunaPark
       it 'should has expected structure' do
         expect(request.title).to eq 'Get users list'
         expect(request.url).to eq 'http://api.example.com/users'
-        expect(request.http_method).to be :get
+        expect(request.method).to be :get
         expect(request.body).to be_nil
         expect(request.headers).to eq('Content-Type' => 'application/x-www-form-urlencoded')
       end
@@ -40,7 +40,7 @@ module LunaPark
       it 'should has expected structure' do
         expect(request.title).to eq 'Add user'
         expect(request.url).to eq 'http://api.example.com/users'
-        expect(request.http_method).to be :post
+        expect(request.method).to be :post
         expect(request.body).to eq '{"name":"John Doe","email":"john.doe@example.com"}'
         expect(request.headers).to eq('Content-Type' => 'application/json')
       end
@@ -49,14 +49,14 @@ module LunaPark
     shared_examples 'send request' do |request_type|
       let(:response) { double }
       let(:driver)   { double(call: response, call!: response) }
-      let(:request)  { Http::Request.new(title: 'Test request', http_method: :get, url: 'example.com', driver: driver) }
+      let(:request)  { Http::Request.new(title: 'Test request', method: :get, url: 'example.com', driver: driver) }
 
       it 'should send request' do
         expect { subject }.to change(request, :sent?).from(false).to(true)
       end
 
       it 'should change request method to get' do
-        expect { subject }.to change(request, :http_method).to(request_type)
+        expect { subject }.to change(request, :method).to(request_type)
       end
 
       it 'should get response' do
@@ -66,7 +66,7 @@ module LunaPark
 
     describe '#get' do
       it_behaves_like 'send request', :get do
-        let(:request)  { Http::Request.new(title: 'Test request', http_method: :post, url: 'example.com', driver: driver) }
+        let(:request)  { Http::Request.new(title: 'Test request', method: :post, url: 'example.com', driver: driver) }
         subject { client.get request }
       end
     end
@@ -97,7 +97,7 @@ module LunaPark
 
     describe '#get!' do
       it_behaves_like 'send request', :get do
-        let(:request) { Http::Request.new(title: 'Test request', http_method: :post, url: 'example.com', driver: driver) }
+        let(:request) { Http::Request.new(title: 'Test request', method: :post, url: 'example.com', driver: driver) }
         subject { client.get! request }
       end
     end

--- a/spec/luna_park/http/request_spec.rb
+++ b/spec/luna_park/http/request_spec.rb
@@ -11,7 +11,7 @@ module LunaPark
     let(:request) do
       described_class.new(
         title: 'Get users',
-        http_method: :get,
+        method: :get,
         url: 'http://example.com',
         body: JSON.generate(message: 'ping'),
         headers: { 'Content-Type': 'application/json' },
@@ -40,23 +40,23 @@ module LunaPark
 
     describe '#title' do
       it 'should be defined in new request instance' do
-        expect { described_class.new(http_method: :get, url: 'http://example.com') }.to raise_error ArgumentError
+        expect { described_class.new(method: :get, url: 'http://example.com') }.to raise_error ArgumentError
       end
 
       it_behaves_like 'mutable argument before request send', :title
     end
 
-    describe '#http_method' do
+    describe '#method' do
       it 'should be defined in new request instance' do
         expect { described_class.new(title: 'Get users', url: 'http://example.com') }.to raise_error ArgumentError
       end
 
-      it_behaves_like 'mutable argument before request send', :http_method
+      it_behaves_like 'mutable argument before request send', :method
     end
 
     describe '#url' do
       it 'should be defined in new request instance' do
-        expect { described_class.new(title: 'Get users', http_method: :get) }.to raise_error ArgumentError
+        expect { described_class.new(title: 'Get users', method: :get) }.to raise_error ArgumentError
       end
 
       it_behaves_like 'mutable argument before request send', :url
@@ -184,7 +184,7 @@ module LunaPark
       it 'should return hash in expected format' do
         is_expected.to eq(
           title: 'Get users',
-          http_method: :get,
+          method: :get,
           url: 'http://example.com',
           body: '{"message":"ping"}',
           headers: { 'Content-Type': 'application/json' },

--- a/spec/luna_park/http/request_spec.rb
+++ b/spec/luna_park/http/request_spec.rb
@@ -79,18 +79,10 @@ module LunaPark
     end
 
     describe '#open_timeout' do
-      it 'if undefined is empty hash' do
-        expect(request.open_timeout).to eq(10)
-      end
-
       it_behaves_like 'mutable argument before request send', :open_timeout
     end
 
     describe '#read_timeout' do
-      it 'if undefined is empty hash' do
-        expect(request.read_timeout).to eq(10)
-      end
-
       it_behaves_like 'mutable argument before request send', :read_timeout
     end
 
@@ -158,33 +150,11 @@ module LunaPark
     describe '#driver' do
       subject { request.driver }
 
-      context 'does not specify' do
-        let(:request) { Http::Request.new(title: 'Example', http_method: :get, url: 'http://yandex.ru') }
+      class Driver; end
+      let(:request) { Http::Request.new(title: 'Example', method: :get, url: 'http://yandex.ru', driver: Driver) }
 
-        it { is_expected.to eq LunaPark::Http::Send }
-      end
-
-      context 'specify at class' do
-        class Driver; end
-
-        let(:request_class) do
-          Class.new(described_class) { driver Driver }
-        end
-
-        let(:request) { request_class.new(title: 'Example', http_method: :get, url: 'http://yandex.ru') }
-
-        it 'should be expected driver' do
-          is_expected.to eq Driver
-        end
-      end
-
-      context 'specify at initialize' do
-        class Driver; end
-        let(:request) { Http::Request.new(title: 'Example', http_method: :get, url: 'http://yandex.ru', driver: Driver) }
-
-        it 'should be expected driver' do
-          is_expected.to eq Driver
-        end
+      it 'should be expected driver' do
+        is_expected.to eq Driver
       end
     end
 
@@ -218,41 +188,10 @@ module LunaPark
           url: 'http://example.com',
           body: '{"message":"ping"}',
           headers: { 'Content-Type': 'application/json' },
-          open_timeout: 10,
-          read_timeout: 10,
+          open_timeout: nil,
+          read_timeout: nil,
           sent_at: nil
         )
-      end
-    end
-
-    describe '.default_driver' do
-      context 'driver is undefined in class' do
-        subject { described_class.default_driver }
-
-        it { is_expected.to eq LunaPark::Http::Send }
-      end
-
-      context 'driver is defined in class' do
-        class Driver; end
-
-        let(:request_class) do
-          Class.new(described_class) { driver Driver }
-        end
-
-        subject { request_class.default_driver }
-
-        it { is_expected.to eq Driver }
-      end
-    end
-
-    describe '.driver' do
-      let(:request_class) { Class.new(described_class) }
-      let(:driver_class) { double }
-
-      it 'should set default driver to class' do
-        expect { request_class.driver(driver_class) }.to change(request_class, :default_driver)
-          .from(LunaPark::Http::Send)
-          .to(driver_class)
       end
     end
   end

--- a/spec/luna_park/http/send_spec.rb
+++ b/spec/luna_park/http/send_spec.rb
@@ -8,7 +8,7 @@ module LunaPark
     let(:request) do
       double(
         url: 'http://example.com',
-        http_method: :post,
+        method: :post,
         body: '{"message":"ping"}',
         headers: { 'Content-Type': 'application/json' },
         open_timeout: 5,


### PR DESCRIPTION
Основная проблема: не понятно разграничение ответственностей между Client и Request. Хорошо заметно что Client пытается взять на себя максимум ответственностей и стать Клиентом, но что в него не влезло - вынесено в Client. Ответственность Client тоже получается довольно неопределённой: только разобраться с Content-Type и всё.

Решение: Request - сделать более глупым, не имеющим DEFAULT_DRIVER и пр.
Клиент - сделать богатой фабрикой Request'ов. Дефолтный драйвер будет определяться в Клиенте, и устанавливаться в Request из него.